### PR TITLE
Changes in  .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - "4"
   - "5"
@@ -11,6 +14,9 @@ matrix:
   include:
     - node_js: "10"
       env: TEST_SUITE=standard
+    - node_js: "10"
+      env: TEST_SUITE=standard
+      arch: ppc64le
 env:
   - TEST_SUITE=unit
 script: npm run-script $TEST_SUITE


### PR DESCRIPTION
Add support for architecture ppc64le.  This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. 
The build and test results are available at the below location.
https://travis-ci.org/github/nageshlop/browserify-cipher/builds/745367379

