### PR TITLE
add RC4 cipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ browserify-cipher
 [![Build Status](https://travis-ci.org/crypto-browserify/browserify-cipher.svg)](https://travis-ci.org/crypto-browserify/browserify-cipher)
 
 Provides createCipher, createDecipher, createCipheriv, createDecipheriv and
-getCiphers for the browserify.  Includes AES and DES ciphers.
+getCiphers for the browserify.  Includes AES, DES and RC4 ciphers.

--- a/browser.js
+++ b/browser.js
@@ -1,3 +1,4 @@
+var RC4 = require('browserify-rc4')
 var DES = require('browserify-des')
 var aes = require('browserify-aes/browser')
 var aesModes = require('browserify-aes/modes')
@@ -14,6 +15,9 @@ function createCipher (suite, password) {
   } else if (desModes[suite]) {
     keyLen = desModes[suite].key * 8
     ivLen = desModes[suite].iv
+  } else if (suite === 'rc4') {
+    keyLen = 16
+    ivLen = 0
   } else {
     throw new TypeError('invalid suite type')
   }
@@ -32,6 +36,9 @@ function createDecipher (suite, password) {
   } else if (desModes[suite]) {
     keyLen = desModes[suite].key * 8
     ivLen = desModes[suite].iv
+  } else if (suite === 'rc4') {
+    keyLen = 16
+    ivLen = 0
   } else {
     throw new TypeError('invalid suite type')
   }
@@ -44,6 +51,7 @@ function createCipheriv (suite, key, iv) {
   suite = suite.toLowerCase()
   if (aesModes[suite]) return aes.createCipheriv(suite, key, iv)
   if (desModes[suite]) return new DES({ key: key, iv: iv, mode: suite })
+  if (suite === 'rc4') return new RC4(key, iv)
 
   throw new TypeError('invalid suite type')
 }
@@ -52,12 +60,13 @@ function createDecipheriv (suite, key, iv) {
   suite = suite.toLowerCase()
   if (aesModes[suite]) return aes.createDecipheriv(suite, key, iv)
   if (desModes[suite]) return new DES({ key: key, iv: iv, mode: suite, decrypt: true })
+  if (suite === 'rc4') return new RC4(key, iv)
 
   throw new TypeError('invalid suite type')
 }
 
 function getCiphers () {
-  return Object.keys(desModes).concat(aes.getCiphers())
+  return Object.keys(desModes).concat(aes.getCiphers()).concat(['rc4'])
 }
 
 exports.createCipher = exports.Cipher = createCipher

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "browserify-aes": "^1.0.4",
     "browserify-des": "^1.0.0",
+    "browserify-rc4": "^1.0.0",
     "evp_bytestokey": "^1.0.0"
   },
   "browser": "browser.js",

--- a/test.js
+++ b/test.js
@@ -53,3 +53,8 @@ Object.keys(desModes).forEach(function (modeName) {
   var mode = desModes[modeName]
   runIvTest(modeName, mode.key, mode.iv)
 })
+
+// rc4 admits arbitrary key sizes
+runIvTest('rc4', 3, 0)
+runIvTest('rc4', 16, 0)
+runIvTest('rc4', 27, 0)


### PR DESCRIPTION
Adds support for the RC4 cipher.

The code for the `browserify-rc4` module is (I didn't publish it myself because I assume you'll want it owned by you):

``` js
var CipherBase = require('cipher-base')
var inherits = require('inherits')
var Buffer = require('safe-buffer').Buffer

function rc4impl (key) {
  var sBox = Array.from(Array(256).keys())
  var i = 0
  var j = 0
  for (i = 0; i < 256; i++) {
    j = (j + sBox[i] + key[i % key.length]) & 0xFF
    var tmp = sBox[i]
    sBox[i] = sBox[j]
    sBox[j] = tmp
  }
  i = 0
  j = 0
  return function getValue () {
    i = (i + 1) & 0xFF
    j = (j + sBox[i]) & 0xFF
    var tmp = sBox[i]
    sBox[i] = sBox[j]
    sBox[j] = tmp
    return sBox[(sBox[i] + sBox[j]) & 0xFF]
  }
}

function RC4 (key, iv) {
  CipherBase.call(this)

  // throw if an IV was passed, to mimic Node
  if (iv && iv.length) {
    throw Error('Invalid IV length')
  }

  if (typeof key === 'string') key = Buffer.from(key)
  this.fn = rc4impl(key)
}

RC4.prototype._update = function (data) {
  data = Buffer.from(data) // create copy
  for (var i = 0; i < data.length; i++) {
    data[i] ^= this.fn()
  }
  return data
}

RC4.prototype._final = function () {
  return Buffer.alloc(0)
}

inherits(RC4, CipherBase)
module.exports = RC4
module.exports.impl = rc4impl
```